### PR TITLE
[feat #79] 동아리리스트 페이지, 동아리 세부사항 페이지 더미데이터로 생성 / 라우트 설정, + seat 마무리

### DIFF
--- a/pupil/src/App.js
+++ b/pupil/src/App.js
@@ -10,6 +10,8 @@ import Wrapper from "./components/Wrapper/Wrapper";
 import WrapperStyles from "./components/Wrapper/Wrapper.module.css";
 import Seat from "./components/Seat/SeatSelection";
 import Scanner from "./pages/Scanner";
+import ClubList from "./components/Club/ClubList";
+import ClubDetail from "./components/Club/ClubDetail";
 
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
@@ -28,6 +30,8 @@ function App() {
               <Route path="/detail" element={<DetailPage />}></Route>
               <Route path="/seat" element={<Seat />}></Route>
               <Route path="/scanner" element={<Scanner></Scanner>}></Route>
+              <Route path="/clublist" element={<ClubList />}></Route>
+              <Route path="/club/:clubId" element={<ClubDetail />}></Route>
             </Routes>
           </Wrapper>
           <Footer />

--- a/pupil/src/components/Club/ClubDetail.js
+++ b/pupil/src/components/Club/ClubDetail.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+
+const clubs = [
+  { id: 1, name: "즉새두", description: "즉새두입니다." },
+  { id: 2, name: "네오", description: "네오입니다." },
+  { id: 3, name: "MIC", description: "MIC입니다." },
+  { id: 4, name: "리퀴드", description: "리퀴드." },
+  {
+    id: 5,
+    name: "하향",
+    description: "하향입니다.",
+  },
+];
+
+function ClubDetail() {
+  const { clubId } = useParams();
+  const club = clubs.find((c) => c.id === parseInt(clubId));
+
+  if (!club) {
+    return <h2>Club not found</h2>;
+  }
+
+  return (
+    <div>
+      <h1>{club.name}</h1>
+      <p>{club.description}</p>
+    </div>
+  );
+}
+
+export default ClubDetail;

--- a/pupil/src/components/Club/ClubList.js
+++ b/pupil/src/components/Club/ClubList.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const clubs = [
+  { id: 1, name: "즉새두" },
+  { id: 2, name: "네오" },
+  { id: 3, name: "mic" },
+  { id: 4, name: "리퀴드" },
+  { id: 5, name: "하향" },
+];
+
+function ClubList() {
+  return (
+    <div>
+      <h1>Clubs</h1>
+      <ul>
+        {clubs.map((club) => (
+          <li key={club.id}>
+            <Link to={`/club/${club.id}`}>{club.name}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default ClubList;

--- a/pupil/src/components/Seat/SeatSelection.js
+++ b/pupil/src/components/Seat/SeatSelection.js
@@ -3,7 +3,7 @@ import Seat from "./Seat";
 import SeatStyle from "./Seat.module.css";
 import { useSelector } from "react-redux";
 import SeatSelectSection from "./SeatSelectSection";
-import SeatType from "../SeatTypeInfo/SeatTypeInfo";
+import SeatType from "./SeatSelectSection.module.css";
 
 const SeatSelection = () => {
   const rows = 5; // 행의 수

--- a/pupil/src/pages/ClubPage.js
+++ b/pupil/src/pages/ClubPage.js
@@ -1,0 +1,13 @@
+import ClubDetail from "../components/Club/ClubDetail";
+import ClubList from "../components/Club/ClubList";
+import Wrapper from "../components/Wrapper/Wrapper";
+
+function ClubPage() {
+  return (
+    <Wrapper>
+      <ClubList />
+    </Wrapper>
+  );
+}
+
+export default ClubPage;


### PR DESCRIPTION
###변경사항
+ Club리스트(동아리 전체 리스트 페이지)
+ Club detail(동아리별 페이지) - 일단 더미로 데이터 전송
+ App.js -> 동아리 페이지 라우트 설정